### PR TITLE
Fix solution update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: npm install
       - run:
           name: Build
-          command: npm build
+          command: npm run build
       - save_cache:
           paths:
             - node_modules
@@ -39,7 +39,7 @@ jobs:
 
 workflows:
   version: 2
-  test-deploy:
+  build-deploy:
     jobs:
       - build:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           - v1-dependencies-
       - run: npm install
       - run:
+          name: Compile iframe html
+          command: npm run srcdoc
+      - run:
           name: Build
           command: npm run build
       - save_cache:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-javascript-tutorials",
   "svelte": "src/Tutorials.svelte",
   "module": "index.mjs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "index.js",
   "author": "Mila Frerichs <mila.frerichs@gmail.com>",

--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -205,7 +205,7 @@
 
 <div class='codemirror-container' class:flex bind:offsetWidth={w} bind:offsetHeight={h}>
 	<textarea
-		tabindex='2'
+		tabindex='0'
 		bind:this={refs.editor}
 		readonly
 		value={code}

--- a/src/Tutorials.svelte
+++ b/src/Tutorials.svelte
@@ -8,7 +8,20 @@
 	let completed = false;
 	let currentChapter = 0;
 	export let chapters = [];
-  export let cssStyles;
+  export let cssStyles = {
+    container: 'container',
+    content: 'content',
+    contentContainer: 'content-actions-container',
+    resultContainer: 'result-container',
+    editor: 'editor',
+    viewer: 'viewer',
+    actions: 'actions',
+    button: {
+      show: 'show',
+      next: 'next',
+      prev: 'prev'
+    }
+  };
 
 	function changeCode(event) {
 		code = event.detail.value;
@@ -16,7 +29,7 @@
 	$: chapter = chapters[currentChapter];
 
 	$: if(ready) {
-		code = chapter.code;
+		code = completed ? chapter.solution : chapter.code;
 		editor.update(code);
 	}
 	function next() {
@@ -27,46 +40,42 @@
 	}
 	function reset() {
 		completed = false;
-		code = chapter.code;
-		editor.update(code);
 	}
 	function complete() {
 		completed = true;
-		code = chapter.solution;
-		editor.update(code);
 	}
 </script>
 
 <style>
 </style>
 
-<div class="container {cssStyles.container}">
-  <div class="content-actions-container {cssStyles.contentContainer}">
-    <div class="content {cssStyles.content}">
+<div class="{cssStyles.container}">
+  <div class="{cssStyles.contentContainer}">
+    <div class="{cssStyles.content}">
       {@html chapter.content}
     </div>
-    <div class="actions {cssStyles.actions}">
-      <button class="show {cssStyles.button.default} {cssStyles.button.show}" on:click="{() => completed ? reset() : complete()}">
+    <div class="{cssStyles.actions}">
+      <button class="{cssStyles.button.default} {cssStyles.button.show}" on:click="{() => completed ? reset() : complete()}">
         {completed ? 'Reset' : 'Show me'}
       </button>
       {#if currentChapter < (chapters.length-1) }
-        <button class="next {cssStyles.button.default} {cssStyles.button.next}" on:click="{() => next()}">
+        <button class="{cssStyles.button.default} {cssStyles.button.next}" on:click="{() => next()}">
           Next
         </button>
       {/if}
       {#if currentChapter > 0 }
-        <button class="prev {cssStyles.button.default} {cssStyles.button.prev}" on:click="{() => prev()}">
+        <button class="{cssStyles.button.default} {cssStyles.button.prev}" on:click="{() => prev()}">
           Previous
         </button>
       {/if}
     </div>
   </div>
-  <div class="result-container {cssStyles.resultContainer}">
+  <div class="{cssStyles.resultContainer}">
   <!-- Using the chapter.code here is a bit hacky, but update does not work in the ready watch, and setting the code earlier will cause the viewer to fail -->
-    <div class="editor {cssStyles.editor}">
+    <div class="{cssStyles.editor}">
       <Editor bind:this={editor} code={chapter.code} on:change={changeCode}/>
     </div>
-    <div class="viewer {cssStyles.viewer}">
+    <div class="{cssStyles.viewer}">
       <Viewer bind:ready code={code} />
     </div>
   </div>

--- a/test/App.svelte
+++ b/test/App.svelte
@@ -4,14 +4,22 @@
 	let chapters = [
 		{
 			content: 'Test',
-			code: 'test',
-			solution: 'test'
+      code: 'document.body.innerHTML = "Test";',
+      solution: 'document.body.innerHTML = "Solution";'
 		},
 		{
-			content: 'Test 2'
+			content: 'Test 2',
+      code: 'document.body.innerHTML = "Test 2";',
+      solution: 'document.body.innerHTML = "Solution 2";'
 		}
 	]
+  let cssStyles = {
+    container: "container",
+    button: {
+      default: 'bla'
+    }
+  }
 </script>
 
-<Tutorials chapters={chapters} />
+<Tutorials {cssStyles} {chapters} />
 


### PR DESCRIPTION
Due to this line
`$: chapter = chapters[currentChapter];`
chapter was changed and this got reevaluated:
```
$: if(ready) {
		code = chapter.code;
		editor.update(code);
```
that resulted in always resetting the code to the `chapter.code` instead of either `chapter.code` or `chapter.solution`
And there for the solution was never set correctly. 

change the styling to use the default or the ones provided. 