### PR TITLE
Add viewOnly option, to just show the output

### DIFF
--- a/src/Tutorials.svelte
+++ b/src/Tutorials.svelte
@@ -1,14 +1,14 @@
 <script>
-	import Viewer from './Viewer.svelte';
-	import Editor from './Editor.svelte';
+  import Viewer from './Viewer.svelte';
+  import Editor from './Editor.svelte';
 
-	let code = '';
-	let ready = false;
-	let editor;
-	let completed = false;
-	let currentChapter = 0;
+  let code = '';
+  let ready = false;
+  let editor;
+  let completed = false;
+  let currentChapter = 0;
   let manualUpdates = false
-	export let chapters = [];
+  export let chapters = [];
   export let cssStyles = {
     container: 'container',
     content: 'content',
@@ -24,35 +24,40 @@
     }
   };
 
-	function changeCode(event) {
+  function changeCode(event) {
     manualUpdates = true
-		code = event.detail.value;
-	}
-	$: chapter = chapters[currentChapter];
+    code = event.detail.value;
+  }
+  $: chapter = chapters[currentChapter];
 
-	$: if(ready && !manualUpdates) {
-		code = completed ? chapter.solution : chapter.code;
-		editor.update(code);
-	}
-	function next() {
+  $: if(ready && !manualUpdates) {
+    code = completed ? chapter.solution : chapter.code;
+    if(editor) editor.update(code);
+  }
+  function next() {
     manualUpdates = false;
-		currentChapter++;
-	}
-	function prev() {
+    completed = false;
+    currentChapter++;
+  }
+  function prev() {
     manualUpdates = false;
-		currentChapter--;
-	}
-	function reset() {
+    completed = false;
+    currentChapter--;
+  }
+  function reset() {
     manualUpdates = false;
-		completed = false;
-	}
-	function complete() {
+    completed = false;
+  }
+  function complete() {
     manualUpdates = false;
-		completed = true;
-	}
+    completed = true;
+  }
 </script>
 
 <style>
+  .hidden {
+    visibility: hidden;
+  }
 </style>
 
 <div class="{cssStyles.container}">
@@ -61,9 +66,11 @@
       {@html chapter.content}
     </div>
     <div class="{cssStyles.actions}">
-      <button class="{cssStyles.button.default} {cssStyles.button.show}" on:click="{() => completed ? reset() : complete()}">
-        {completed ? 'Reset' : 'Show me'}
-      </button>
+      {#if !chapter.viewOnly }
+        <button class="{cssStyles.button.default} {cssStyles.button.show}" on:click="{() => completed ? reset() : complete()}">
+          {completed ? 'Reset' : 'Show me'}
+        </button>
+      {/if}
       {#if currentChapter < (chapters.length-1) }
         <button class="{cssStyles.button.default} {cssStyles.button.next}" on:click="{() => next()}">
           Next
@@ -78,9 +85,11 @@
   </div>
   <div class="{cssStyles.resultContainer}">
   <!-- Using the chapter.code here is a bit hacky, but update does not work in the ready watch, and setting the code earlier will cause the viewer to fail -->
-    <div class="{cssStyles.editor}">
-      <Editor bind:this={editor} on:change={changeCode}/>
-    </div>
+    {#if !chapter.viewOnly }
+      <div class:hidden="{chapter.viewOnly}" class="{cssStyles.editor}">
+        <Editor bind:this={editor} on:change={changeCode}/>
+      </div>
+    {/if}
     <div class="{cssStyles.viewer}">
       <Viewer bind:ready {code} />
     </div>

--- a/test/App.svelte
+++ b/test/App.svelte
@@ -5,7 +5,8 @@
 		{
 			content: 'Test',
       code: 'document.body.innerHTML = "Test";',
-      solution: 'document.body.innerHTML = "Solution";'
+      solution: 'document.body.innerHTML = "Solution";',
+      viewOnly: true
 		},
 		{
 			content: 'Test 2',


### PR DESCRIPTION
## What does this PR do?

It adds the option to just show the result and not show the code
internally we hide the editor; might change in the future, but good for now

good for an intro to a chapter where we just have the result of that tutorial
add: `viewOnly: true` to the chapter definition