### PR TITLE
Improve view console switcher

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# v0.0.10
+## Added
+- active state for the switcher
+- view-only class when only the view screen is visible
+
 # v0.0.9
 ## Added
 - Switcher between Result and Console

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-javascript-tutorials",
   "svelte": "src/Tutorials.svelte",
   "module": "index.mjs",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "index.js",
   "author": "Mila Frerichs <mila.frerichs@gmail.com>",

--- a/src/Tutorials.svelte
+++ b/src/Tutorials.svelte
@@ -46,11 +46,13 @@
   function next() {
     manualUpdates = false;
     completed = false;
+    tab = 'viewer';
     currentChapter++;
   }
   function prev() {
     manualUpdates = false;
     completed = false;
+    tab = 'viewer';
     currentChapter--;
   }
   function reset() {
@@ -104,13 +106,13 @@
         <Editor bind:this={editor} on:change={changeCode}/>
       </div>
     {/if}
-    <div class="{cssStyles.viewerContainer}">
+    <div class:view-only="{chapter.viewOnly}" class="{cssStyles.viewerContainer}">
       <div class="{cssStyles.viewerActions.container}">
         <div class="{cssStyles.viewerActions.tabItem}">
-          <a class="{cssStyles.viewerActions.link}" on:click="{() => showResult()}">Result</a>
+          <a class:active="{tab == 'viewer'}" class="{cssStyles.viewerActions.link}" on:click="{() => showResult()}">Result</a>
         </div>
         <div class="{cssStyles.viewerActions.tabItem}">
-          <a class="{cssStyles.viewerActions.link}" on:click="{() => showConsole()}">Console</a>
+          <a class:active="{tab == 'console'}" class="{cssStyles.viewerActions.link}" on:click="{() => showConsole()}">Console</a>
         </div>
       </div>
       <div class="{cssStyles.viewerConsoleContainer}">


### PR DESCRIPTION
add `active` class to the view switcher
add `view-only` class when the editor is not visible