### PR TITLE
Fix: viewer needs to be ready before we send the first message

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "javascript-repl",
   "svelte": "src/Repl.svelte",
   "module": "index.mjs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "index.js",
   "author": "Mila Frerichs <mila.frerichs@gmail.com>",

--- a/src/Repl.svelte
+++ b/src/Repl.svelte
@@ -136,10 +136,10 @@
       </div>
       <div class="{cssStyles.viewerConsoleContainer}">
         <div class:hidden="{tab != 'viewer'}" class="{cssStyles.viewer}">
-          <Viewer bind:ready {code} {injectedLibraries} {html} {injectedJS} />
+          <Viewer bind:ready={ready} {code} {injectedLibraries} {html} {injectedJS} />
         </div>
         <div class:hidden="{tab != 'console'}" class="{cssStyles.console}">
-          <Console bind:ready output={code} />
+          <Console output={code} />
         </div>
       </div>
     </div>

--- a/src/Viewer.svelte
+++ b/src/Viewer.svelte
@@ -7,14 +7,14 @@
   export let injectedLibraries = [];
   export let html = '';
 	export let code = '';
-	export let ready;
+	export let ready = false;
 	let message = '';
 	onMount(() => {
 		iframe.addEventListener('load', () => {
 			ready = true;
 		});
 	});
-	$: if(code || html) {
+	$: if(ready && (code || html)) {
 		message = `
     ${injectedJS}
     ${styles}


### PR DESCRIPTION
when the viewer (iframe) is not ready to receive messages yet we need to
wait for changes to ready to send messages to the iframe, we do that in
the load event listener but forgot to listen to it in the sned message
also fix the way the ready flag is bound between the Repl and the Viewer
components