### PR TITLE
fix: layout changes should not result in failure

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v0.4.4
+##Fixed
+Changing the layout should not break the code. And the iframes should now always be available when we post messages to them.
+
 # v0.3.0
 ## Added
 New `mode` prop

--- a/example/App.svelte
+++ b/example/App.svelte
@@ -1,7 +1,10 @@
 <style>
+  :global(.container) {
+    height: 100vh;
+  }
   :global(.tutorial-container) {
     width: 100%;
-    height: 100%;
+    height: 100vh;
     display: flex;
   }
   :global(.content-container) {
@@ -81,11 +84,16 @@
       type: 'js'
     }
   ];
+  let layout = 'default'
   function changedCode() {
     console.log('changed the code')
+  }
+  function changeLayout() {
+    layout = (layout === 'default' ? 'view' : 'default');
   }
 
 </script>
 
-<Repl layout={'default'} {files} />
+<a href="javascript:;" on:click={changeLayout}>Change Layout</a>
+<Repl  {layout} {files} />
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "javascript-repl",
   "svelte": "src/Repl.svelte",
   "module": "index.mjs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "main": "index.js",
   "author": "Mila Frerichs <mila.frerichs@gmail.com>",

--- a/src/Console.svelte
+++ b/src/Console.svelte
@@ -26,4 +26,4 @@
 		`
 	}
 </script>
-<Result {width} {height} html={''} code={message} />
+<Result name={'console'} {width} {height} html={''} code={message} />

--- a/src/Result.svelte
+++ b/src/Result.svelte
@@ -1,11 +1,11 @@
 <script>
 	import srcdoc from './srcdoc/index.js';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 
   import {
-    ready,
     injectedJS,
-    injectedLibraries
+    injectedLibraries,
+    iframeReady
   } from './stores.js'
 
 	let iframe;
@@ -14,14 +14,25 @@
   export let height;
   export let code;
   export let html;
+  export let name = 'viewer';
+  let ready = false;
 
 	let message = '';
+
+  const setReady = () => {
+    iframeReady.setReady(true, name)
+    iframeReady.subscribe((value) => {
+      ready = value[name] || false;
+    })
+  }
 	onMount(() => {
-		iframe.addEventListener('load', () => {
-			ready.set(true);
-		});
+		iframe.addEventListener('load', setReady);
 	});
-	$: if($ready && (code || html)) {
+	onDestroy(() => {
+    iframeReady.setReady(false, name)
+		iframe.removeEventListener('load', setReady);
+	});
+	$: if(ready && iframe && (code || html)) {
 		message = `
     ${$injectedJS}
     ${styles}

--- a/src/Viewer.svelte
+++ b/src/Viewer.svelte
@@ -7,4 +7,4 @@
 
 </script>
 
-<Result {width} {height} code={$code} html={$html} />
+<Result name={'viewer'} {width} {height} code={$code} html={$html} />

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,6 +1,5 @@
 import { writable, derived } from 'svelte/store';
 
-export const ready = writable(false);
 export const code = writable('');
 export const html = writable('');
 export const tab = writable('viewer');
@@ -15,3 +14,18 @@ export const currentFile = derived(
   [files, currentFileIndex],
   ([$files, $currentFileIndex]) => $files[$currentFileIndex]
 );
+
+const createIframe = () => {
+  const { subscribe, set, update } = writable({});
+
+  return {
+    subscribe,
+    setReady: (ready, name) => {
+      return update((n) => {
+        n[name] = ready;
+        return n;
+      })
+    }
+  }
+}
+export const iframeReady = createIframe();


### PR DESCRIPTION
previously we only set ready in the store once, but we have multiple
iframes from multiple layouts and when you change the layout the iframe
might not be ready yet and we cannot post to it.
remove the evnetlistener, and reset it to false on destroy